### PR TITLE
Embedded attack type into each word (for non-bus-based simulation)

### DIFF
--- a/pkg/src/attacks/attack1.rs
+++ b/pkg/src/attacks/attack1.rs
@@ -1,6 +1,6 @@
 use crate::sys::{
     DefaultEventHandler, DefaultScheduler, Device, ErrMsg, EventHandler, Mode, Router, System,
-    Word, WRD_EMPTY,
+    Word, WRD_EMPTY, AttackType
 };
 
 #[derive(Clone, Debug)]
@@ -77,9 +77,9 @@ pub fn test_attack1() {
         };
 
         if m == 0 {
-            sys.run_d(m as u8, Mode::BC, default_router, false, 0);
+            sys.run_d(m as u8, Mode::BC, default_router, AttackType::Benign);
         } else {
-            sys.run_d(m as u8, Mode::RT, default_router, false, 0);
+            sys.run_d(m as u8, Mode::RT, default_router, AttackType::Benign);
         }
     }
     let attacker_router = Router {
@@ -98,7 +98,7 @@ pub fn test_attack1() {
         },
     };
 
-    sys.run_d(n_devices - 1, Mode::RT, attacker_router, false, 1);
+    sys.run_d(n_devices - 1, Mode::RT, attacker_router, AttackType::AtkCollisionAttackAgainstTheBus);
     sys.go();
     sys.sleep_ms(10);
     sys.stop();

--- a/pkg/src/attacks/attack10.rs
+++ b/pkg/src/attacks/attack10.rs
@@ -1,6 +1,6 @@
 use crate::sys::{
     DefaultEventHandler, DefaultScheduler, Device, ErrMsg, EventHandler, Mode, Router, System,
-    Word, WRD_EMPTY,
+    Word, WRD_EMPTY, AttackType
 };
 
 #[derive(Clone, Debug)]
@@ -66,9 +66,9 @@ pub fn test_attack10() {
         };
 
         if m == 0 {
-            sys.run_d(m as u8, Mode::BC, default_router, false, 0);
+            sys.run_d(m as u8, Mode::BC, default_router, AttackType::Benign);
         } else {
-            sys.run_d(m as u8, Mode::RT, default_router, false, 0);
+            sys.run_d(m as u8, Mode::RT, default_router, AttackType::Benign);
         }
     }
     let attacker_router = Router {
@@ -88,7 +88,7 @@ pub fn test_attack10() {
         },
     };
 
-    sys.run_d(n_devices - 1, Mode::RT, attacker_router, false, 1);
+    sys.run_d(n_devices - 1, Mode::RT, attacker_router, AttackType::AtkCommandInvalidationAttack);
     sys.go();
     sys.sleep_ms(10);
     sys.stop();

--- a/pkg/src/attacks/attack10.rs
+++ b/pkg/src/attacks/attack10.rs
@@ -4,58 +4,47 @@ use crate::sys::{
 };
 
 #[derive(Clone, Debug)]
-pub struct CollisionAttackAgainstTheBus {
-    pub nwords_inj: u32,
-    pub started: u128,
+pub struct CommandInvalidationAttack {
+    pub attack_times: Vec<u128>,
     pub success: bool,
+    pub target: u8,         // the target RT
+    pub target_found: bool, // target found in traffic
 }
 
-impl CollisionAttackAgainstTheBus {
+impl CommandInvalidationAttack {
     pub fn inject(&mut self, d: &mut Device) {
-        if self.started == 0 {
-            self.started = d.clock.elapsed().as_nanos();
-            self.success = true;
-        }
-        for i in 0..self.nwords_inj {
-            let w = Word::new_data(i as u32);
-            d.log(
-                WRD_EMPTY,
-                ErrMsg::MsgAttk(format!("Sent Fake Data {} ", w).to_string()),
-            );
-            d.write(w);
-        }
+        self.attack_times.push(d.clock.elapsed().as_nanos());
+        let dword_count = 31;    // Maximum number of words.  This will mean the receipient ignores the next 31 messages
+        let tr = 0;              // 1: transmit, 0: receive.  We want to receive because it will sit and wait rather than responding to the BC.
+        let w = Word::new_cmd(self.target, dword_count, tr);
+        d.log(
+            WRD_EMPTY,
+            ErrMsg::MsgAttk(format!("Attacker>> Injecting fake command on RT{}", w).to_string()),
+        );
+        d.write(w);
+        self.success = true;
     }
 }
 
-impl EventHandler for CollisionAttackAgainstTheBus {
+impl EventHandler for CommandInvalidationAttack {
     fn on_cmd(&mut self, d: &mut Device, w: &mut Word) {
-        d.log(
-            *w,
-            ErrMsg::MsgAttk("Jamming launched (after cmd)".to_string()),
-        );
-        self.inject(d);
+        // This function replaces "find_RT_tcmd" from Michael's code
+        // We cannot use on_cmd_trx here because that only fires after on_cmd verifies that the address is correct.
+        let destination = w.address();
+        if destination == self.target && self.target_found==false && w.tr() == 1 {
+            d.log(
+                *w, 
+                ErrMsg::MsgAttk(format!("Attacker>> Target detected(RT{})", self.target).to_string()),
+            );
+            self.target_found = true;
+            self.inject(d);
+        }
         self.default_on_cmd(d, w);
-    }
-    fn on_dat(&mut self, d: &mut Device, w: &mut Word) {
-        d.log(
-            *w,
-            ErrMsg::MsgAttk("Jamming launched (after data)".to_string()),
-        );
-        self.inject(d);
-        self.default_on_dat(d, w);
-    }
-    fn on_sts(&mut self, d: &mut Device, w: &mut Word) {
-        d.log(
-            *w,
-            ErrMsg::MsgAttk("Jamming launched (after status)".to_string()),
-        );
-        self.inject(d);
-        self.default_on_dat(d, w);
     }
 }
 
 #[allow(dead_code)]
-pub fn test_attack0() {
+pub fn test_attack10() {
     // let mut delays_single = Vec::new();
     let n_devices = 8;
     // normal device has 4ns delays (while attacker has zero)
@@ -91,10 +80,11 @@ pub fn test_attack0() {
             proto: 0,
         },
         // control device-level response
-        handler: CollisionAttackAgainstTheBus {
-            nwords_inj: 5,
-            started: 0,
+        handler: CommandInvalidationAttack {
+            attack_times: Vec::new(),
             success: false,
+            target: 4, // attacking RT address @4
+            target_found: false,
         },
     };
 

--- a/pkg/src/attacks/attack2.rs
+++ b/pkg/src/attacks/attack2.rs
@@ -4,51 +4,66 @@ use crate::sys::{
 };
 
 #[derive(Clone, Debug)]
-pub struct DataThrashingAgainstRT {
+pub struct CollisionAttackAgainstAnRT {
+    pub nwords_inj: u8,
     pub attack_times: Vec<u128>,
     pub success: bool,
-    pub word_count: u8,
     pub target: u8,         // the target RT
     pub target_found: bool, // target found in traffic
+    pub wc_n: u16,          // words to be injected
 }
 
-impl DataThrashingAgainstRT {
-    fn inject_words(&mut self, d: &mut Device) {
+impl CollisionAttackAgainstAnRT {
+    pub fn inject(&mut self, d: &mut Device) {
         self.attack_times.push(d.clock.elapsed().as_nanos());
-        let word_count = 30;
-        let tr = 0;
-        let w = Word::new_cmd(self.target, word_count, tr);
-        d.write(w);
         self.success = true;
+        for i in 0..self.nwords_inj {
+            let w = Word::new_data(i as u32);
+            d.log(
+                WRD_EMPTY,
+                ErrMsg::MsgAttk(format!("Sent Fake Data {} ", w).to_string()),
+            );
+            d.write(w);
+        }
     }
 }
 
-impl EventHandler for DataThrashingAgainstRT {
+impl EventHandler for CollisionAttackAgainstAnRT {
     fn on_cmd(&mut self, d: &mut Device, w: &mut Word) {
-        // This replaces 'jam_cmdwords' from Michael's code
-        if w.address() == self.target && w.tr() == 0 {
-            self.target_found = true;
-            self.word_count = w.dword_count();
+        if w.address() == self.target {
             d.log(
-                WRD_EMPTY, 
-                ErrMsg::MsgAttk(format!("Thrashing triggered (after cmd_word)").to_string()),
+                *w,
+                ErrMsg::MsgAttk("Jamming launched (after cmd)".to_string()),
             );
+            self.nwords_inj = w.dword_count();
+            self.target_found = true;
+            self.inject(d);
         }
         self.default_on_cmd(d, w);
     }
-
     fn on_dat(&mut self, d: &mut Device, w: &mut Word) {
-        // This replaces 'jam_datawords' from Michael's code
-        if self.target_found {
-            self.word_count -= 1;
-            if self.word_count == 0 {
+        if w.address() == self.target && self.target_found {
+            d.log(
+                *w,
+                ErrMsg::MsgAttk("Jamming launched (after data)".to_string()),
+            );
+            self.inject(d);
+            self.wc_n -= 1;
+            if self.wc_n == 0 {
+                // attacker has recieved the equivalent number
+                // of messages
                 self.target_found = false;
-                d.log(
-                    WRD_EMPTY, 
-                    ErrMsg::MsgAttk(format!("Fake command injected!").to_string()),
-                );
-                self.inject_words(d);
             }
+        }
+        self.default_on_dat(d, w);
+    }
+    fn on_sts(&mut self, d: &mut Device, w: &mut Word) {
+        if w.address() == self.target {
+            d.log(
+                *w,
+                ErrMsg::MsgAttk("Jamming launched (after status)".to_string()),
+            );
+            self.inject(d);
         }
         self.default_on_dat(d, w);
     }
@@ -91,11 +106,12 @@ pub fn test_attack2() {
             proto: 0,
         },
         // control device-level response
-        handler: DataThrashingAgainstRT {
+        handler: CollisionAttackAgainstAnRT {
+            nwords_inj: 0,
             attack_times: Vec::new(),
-            word_count: 0u8,
             success: false,
-            target: 2, // attacking RT address @2
+            target: 5, // attacking RT address @5
+            wc_n: 0,   // expected word count (intercepted)
             target_found: false,
         },
     };

--- a/pkg/src/attacks/attack2.rs
+++ b/pkg/src/attacks/attack2.rs
@@ -1,6 +1,6 @@
 use crate::sys::{
     DefaultEventHandler, DefaultScheduler, Device, ErrMsg, EventHandler, Mode, Router, System,
-    Word, WRD_EMPTY,
+    Word, WRD_EMPTY, AttackType
 };
 
 #[derive(Clone, Debug)]
@@ -92,9 +92,9 @@ pub fn test_attack2() {
         };
 
         if m == 0 {
-            sys.run_d(m as u8, Mode::BC, default_router, false, 0);
+            sys.run_d(m as u8, Mode::BC, default_router, AttackType::Benign);
         } else {
-            sys.run_d(m as u8, Mode::RT, default_router, false, 0);
+            sys.run_d(m as u8, Mode::RT, default_router, AttackType::Benign);
         }
     }
     let attacker_router = Router {
@@ -116,7 +116,7 @@ pub fn test_attack2() {
         },
     };
 
-    sys.run_d(n_devices - 1, Mode::RT, attacker_router, false, 1);
+    sys.run_d(n_devices - 1, Mode::RT, attacker_router,  AttackType::AtkCollisionAttackAgainstAnRT);
     sys.go();
     sys.sleep_ms(10);
     sys.stop();

--- a/pkg/src/attacks/attack3.rs
+++ b/pkg/src/attacks/attack3.rs
@@ -1,6 +1,6 @@
 use crate::sys::{
     DefaultEventHandler, DefaultScheduler, Device, ErrMsg, EventHandler, Mode, Router, System,
-    Word, WRD_EMPTY,
+    Word, WRD_EMPTY, AttackType
 };
 
 #[derive(Clone, Debug)]
@@ -77,9 +77,9 @@ pub fn test_attack3() {
         };
 
         if m == 0 {
-            sys.run_d(m as u8, Mode::BC, default_router, false, 0);
+            sys.run_d(m as u8, Mode::BC, default_router, AttackType::Benign);
         } else {
-            sys.run_d(m as u8, Mode::RT, default_router, false, 0);
+            sys.run_d(m as u8, Mode::RT, default_router, AttackType::Benign);
         }
     }
     let attacker_router = Router {
@@ -100,7 +100,7 @@ pub fn test_attack3() {
         },
     };
 
-    sys.run_d(n_devices - 1, Mode::RT, attacker_router, false, 1);
+    sys.run_d(n_devices - 1, Mode::RT, attacker_router, AttackType::AtkDataThrashingAgainstRT);
     sys.go();
     sys.sleep_ms(10);
     sys.stop();

--- a/pkg/src/attacks/attack4.rs
+++ b/pkg/src/attacks/attack4.rs
@@ -1,6 +1,6 @@
 use crate::sys::{
     DefaultEventHandler, DefaultScheduler, Device, ErrMsg, EventHandler, Mode, Router, System,
-    Word, WRD_EMPTY, State,
+    Word, WRD_EMPTY, State, AttackType
 };
 
 #[derive(Clone, Debug)]
@@ -106,9 +106,9 @@ pub fn test_attack4() {
         };
 
         if m == 0 {
-            sys.run_d(m as u8, Mode::BC, default_router, false, 0);
+            sys.run_d(m as u8, Mode::BC, default_router, AttackType::Benign);
         } else {
-            sys.run_d(m as u8, Mode::RT, default_router, false, 0);
+            sys.run_d(m as u8, Mode::RT, default_router, AttackType::Benign);
         }
     }
     let attacker_router = Router {
@@ -133,7 +133,7 @@ pub fn test_attack4() {
         },
     };
 
-    sys.run_d(n_devices - 1, Mode::RT, attacker_router, false, 1);
+    sys.run_d(n_devices - 1, Mode::RT, attacker_router, AttackType::AtkMITMAttackOnRTs);
     sys.go();
     sys.sleep_ms(10);
     sys.stop();

--- a/pkg/src/attacks/attack4.rs
+++ b/pkg/src/attacks/attack4.rs
@@ -4,53 +4,82 @@ use crate::sys::{
 };
 
 #[derive(Clone, Debug)]
-pub struct ShutdownAttackRT {
+pub struct MITMAttackOnRTs {
     pub attack_times: Vec<u128>,
     pub success: bool,
     pub word_count: u8,
-    pub target: u8,         // the target RT
-    pub target_found: bool, // target found in traffic
+    pub injected_words: u8,
+    pub target_src: u8,
+    pub target_dst: u8,
+    pub target_dst_found: bool, // target found in traffic
+    pub target_src_found: bool,
+    pub done: bool,
 }
 
-impl ShutdownAttackRT {
-    fn kill_rt(&mut self, d: &mut Device) {
+impl MITMAttackOnRTs {
+    fn start_mitm(&mut self, d: &mut Device) {
         d.log(
-            WRD_EMPTY,
-            ErrMsg::MsgAttk(format!("Attacker>> Killing RT{}", self.target).to_string()),
+            WRD_EMPTY, 
+            ErrMsg::MsgAttk(format!("Starting MITM attack...").to_string()),
         );
-        let word_count = 4;
-        let tr = 1;
         self.attack_times.push(d.clock.elapsed().as_nanos());
-        let w = Word::new_cmd(self.target, word_count, tr);
+        d.set_state(State::Off);
+        let word_count = self.injected_words;
+        let tr = 0;
+        let mut w = Word::new_cmd(self.target_src, word_count, tr);
         d.write(w);
-        self.success = true;
-        d.set_state(State::Off); // Not sure what's going on here yet.  TODO come back to this.
+        w.set_address(self.target_dst);
+        w.set_tr(1);
+        d.write(w);
+        self.done = true;
+        //sleep(time_next_attack) // figure out how to add delays // default is 10
+        d.set_state(State::Idle);
     }
 }
 
-impl EventHandler for ShutdownAttackRT {
+impl EventHandler for MITMAttackOnRTs {
     fn on_cmd(&mut self, d: &mut Device, w: &mut Word) {
-        if w.address() == self.target && self.target_found == false {
-            d.log(
-                WRD_EMPTY,
-                ErrMsg::MsgAttk(format!("Attacker>> Killing RT{}", self.target).to_string()),
-            );
-            self.target_found = true;
-            self.kill_rt(d);
+        if !(self.target_src_found && self.target_dst_found) && !self.done {
+            if w.tr() == 0 && !self.target_dst_found && w.address() != 31 {
+                self.target_dst = w.address();
+                self.target_dst_found = true;
+                self.word_count = w.dword_count();
+                if self.injected_words == 0 {
+                    self.injected_words = w.dword_count();
+                }
+                d.log(
+                    WRD_EMPTY, 
+                    ErrMsg::MsgAttk(format!("Atttacker>> Target dst identified (RT{})", self.target_dst).to_string()),
+                );
+            } else if w.tr() == 1 && !self.target_src_found && w.address() != 31 {
+                self.target_src = w.address();
+                self.target_src_found = true;
+                d.log(
+                    WRD_EMPTY, 
+                    ErrMsg::MsgAttk(format!("Atttacker>> Target src identified (RT{})", self.target_src).to_string()),
+                );
+            }
         }
         self.default_on_cmd(d, w);
     }
 
     fn on_sts(&mut self, d: &mut Device, w: &mut Word) {
-        if w.address() == self.target && self.target_found == false {
+        // This replaces "getReady_for_MITM" from Michael's code
+        if self.target_src == w.address() && !self.done {
+            if self.target_dst_found && self.target_src_found {
+                //sleep(self.delay);
+                self.start_mitm(d);
+            }
+        } else if self.target_src == w.address() && self.done {
             d.log(
-                WRD_EMPTY,
-                ErrMsg::MsgAttk(format!("Attacker>> Killing RT{}", self.target).to_string()),
+                WRD_EMPTY, 
+                ErrMsg::MsgAttk(format!("Attacker>> Man in the Middle Successfully Completed!")),
             );
-            self.target_found = true;
-            self.kill_rt(d);
+            self.success = true;
+            self.target_src_found = false;
+            self.target_dst_found = false;
+            self.done = false;
         }
-        self.default_on_sts(d, w);
     }
 }
 
@@ -91,12 +120,16 @@ pub fn test_attack4() {
             proto: 0,
         },
         // control device-level response
-        handler: ShutdownAttackRT {
+        handler: MITMAttackOnRTs {
             attack_times: Vec::new(),
             word_count: 0u8,
+            injected_words: 0u8,
             success: false,
-            target: 4, // attacking RT address @4
-            target_found: false,
+            target_src: 0u8,
+            target_dst: 0u8,
+            target_dst_found: false, // target found in traffic
+            target_src_found: false,
+            done: false,
         },
     };
 

--- a/pkg/src/attacks/attack5.rs
+++ b/pkg/src/attacks/attack5.rs
@@ -1,6 +1,6 @@
 use crate::sys::{
     DefaultEventHandler, DefaultScheduler, Device, ErrMsg, EventHandler, Mode, Router, System,
-    Word, WRD_EMPTY, State,
+    Word, WRD_EMPTY, State, AttackType
 };
 
 #[derive(Clone, Debug)]
@@ -77,9 +77,9 @@ pub fn test_attack5() {
         };
 
         if m == 0 {
-            sys.run_d(m as u8, Mode::BC, default_router, false, 0);
+            sys.run_d(m as u8, Mode::BC, default_router, AttackType::Benign);
         } else {
-            sys.run_d(m as u8, Mode::RT, default_router, false, 0);
+            sys.run_d(m as u8, Mode::RT, default_router, AttackType::Benign);
         }
     }
     let attacker_router = Router {
@@ -100,7 +100,7 @@ pub fn test_attack5() {
         },
     };
 
-    sys.run_d(n_devices - 1, Mode::RT, attacker_router, false, 1);
+    sys.run_d(n_devices - 1, Mode::RT, attacker_router, AttackType::AtkShutdownAttackRT);
     sys.go();
     sys.sleep_ms(10);
     sys.stop();

--- a/pkg/src/attacks/attack6.rs
+++ b/pkg/src/attacks/attack6.rs
@@ -1,6 +1,6 @@
 use crate::sys::{
     DefaultEventHandler, DefaultScheduler, Device, ErrMsg, EventHandler, Mode, Router, System,
-    Word, WRD_EMPTY,
+    Word, WRD_EMPTY, AttackType
 };
 
 #[derive(Clone, Debug)]
@@ -95,9 +95,9 @@ pub fn test_attack6() {
         };
 
         if m == 0 {
-            sys.run_d(m as u8, Mode::BC, default_router, false, 0);
+            sys.run_d(m as u8, Mode::BC, default_router, AttackType::Benign);
         } else {
-            sys.run_d(m as u8, Mode::RT, default_router, false, 0);
+            sys.run_d(m as u8, Mode::RT, default_router, AttackType::Benign);
         }
     }
     let attacker_router = Router {
@@ -119,7 +119,7 @@ pub fn test_attack6() {
         },
     };
 
-    sys.run_d(n_devices - 1, Mode::RT, attacker_router, false, 1);
+    sys.run_d(n_devices - 1, Mode::RT, attacker_router, AttackType::AtkFakeStatusReccmd);
     sys.go();
     sys.sleep_ms(10);
     sys.stop();

--- a/pkg/src/attacks/attack6.rs
+++ b/pkg/src/attacks/attack6.rs
@@ -4,15 +4,18 @@ use crate::sys::{
 };
 
 #[derive(Clone, Debug)]
-pub struct FakeStatusTrcmd {
+pub struct FakeStatusReccmd {
     pub attack_times: Vec<u128>,
     pub success: bool,
+    pub word_count: u8,
     pub target: u8,         // the target RT
     pub target_found: bool, // target found in traffic
+    pub destination: u8,
 }
 
-impl FakeStatusTrcmd {
+impl FakeStatusReccmd {
     fn fake_status(&mut self, d: &mut Device) {
+        self.target_found = false;
         self.attack_times.push(d.clock.elapsed().as_nanos());
         let w = Word::new_status(self.target);
         d.write(w);
@@ -20,38 +23,52 @@ impl FakeStatusTrcmd {
             WRD_EMPTY,
             ErrMsg::MsgAttk(format!("Fake status injected!").to_string()),
         );
-        self.target_found = false;
         self.success = true;
     }
 }
 
-impl EventHandler for FakeStatusTrcmd {
+impl EventHandler for FakeStatusReccmd {
     fn on_cmd(&mut self, d: &mut Device, w: &mut Word) {
         let destination = w.address();
         // if w.address() != self.address {} //This line won't work yet.  TODO: Get our address.
-        if self.target != 2u8.pow(5) - 1 { 
-            if destination == self.target && w.tr() == 1 && !self.target_found {
+        if self.target != 2u8.pow(5) - 1 && destination == self.target && w.tr() == 0 {
                 d.log(
                     WRD_EMPTY,
                     ErrMsg::MsgAttk(format!("Attacker>> Target detected (RT{})", self.target).to_string()),
                 );
                 self.target_found = true;
+                self.word_count = w.dword_count();
+                self.destination = w.address();
                 d.log(
                     WRD_EMPTY, 
-                    ErrMsg::MsgAttk(format!("Sending fake status word (after tr_cmd_word)").to_string()),
+                    ErrMsg::MsgAttk(format!("Fake status triggered (after cmd_word)").to_string()),
                 );
-                self.fake_status(d);
-            }
         } else {
-            if w.tr() == 1 && destination != 31 {
+            if w.tr() == 0 && destination != 31 {
                 d.log(
                     WRD_EMPTY,
-                    ErrMsg::MsgAttk(format!("Sending fake status word (after tr_cmd_word)")),
+                    ErrMsg::MsgAttk(format!("Attacker>> Target detected (RT{})", w.address()).to_string()),
                 );
-                self.fake_status(d);
+                self.target_found = true;
+                self.word_count = w.dword_count();
+                self.destination = w.address();
+                d.log(
+                    WRD_EMPTY,
+                    ErrMsg::MsgAttk(format!("Fake status triggered (after cmd_word)").to_string()),
+                );
             }
         }
         self.default_on_cmd(d, w);
+    }
+
+    fn on_dat(&mut self, d: &mut Device, w: &mut Word) {
+        // This takes the place of "intercept_dw" in Michael's code
+        if self.target_found && w.data() != 0xffff {
+            self.word_count -= 1;
+            if self.word_count == 0 {
+                self.fake_status(d);
+            }
+        }
     }
 }
 
@@ -92,11 +109,13 @@ pub fn test_attack6() {
             proto: 0,
         },
         // control device-level response
-        handler: FakeStatusTrcmd {
+        handler: FakeStatusReccmd {
             attack_times: Vec::new(),
+            word_count: 0u8,
             success: false,
             target: 4, // attacking RT address @4
             target_found: false,
+            destination: 0u8,
         },
     };
 

--- a/pkg/src/attacks/attack7.rs
+++ b/pkg/src/attacks/attack7.rs
@@ -1,6 +1,6 @@
 use crate::sys::{
     DefaultEventHandler, DefaultScheduler, Device, ErrMsg, EventHandler, Mode, Router, System,
-    Word, WRD_EMPTY,
+    Word, WRD_EMPTY, AttackType
 };
 
 #[derive(Clone, Debug)]
@@ -78,9 +78,9 @@ pub fn test_attack7() {
         };
 
         if m == 0 {
-            sys.run_d(m as u8, Mode::BC, default_router, false, 0);
+            sys.run_d(m as u8, Mode::BC, default_router, AttackType::Benign);
         } else {
-            sys.run_d(m as u8, Mode::RT, default_router, false, 0);
+            sys.run_d(m as u8, Mode::RT, default_router, AttackType::Benign);
         }
     }
     let attacker_router = Router {
@@ -100,7 +100,7 @@ pub fn test_attack7() {
         },
     };
 
-    sys.run_d(n_devices - 1, Mode::RT, attacker_router, false, 1);
+    sys.run_d(n_devices - 1, Mode::RT, attacker_router, AttackType::AtkFakeStatusTrcmd);
     sys.go();
     sys.sleep_ms(10);
     sys.stop();

--- a/pkg/src/attacks/attack8.rs
+++ b/pkg/src/attacks/attack8.rs
@@ -4,50 +4,83 @@ use crate::sys::{
 };
 
 #[derive(Clone, Debug)]
-pub struct DataCorruptionAttack {
+pub struct DesynchronizationAttackOnRT {
     pub attack_times: Vec<u128>,
     pub success: bool,
     pub word_count: u8,
+    pub flag: u8,
     pub target: u8,         // the target RT
     pub target_found: bool, // target found in traffic
 }
 
-impl DataCorruptionAttack {
-    pub fn inject(&mut self, d: &mut Device) {
+impl DesynchronizationAttackOnRT {
+    fn desynchronize_rt(&mut self, d: &mut Device) {
         d.log(
-            WRD_EMPTY, 
-            ErrMsg::MsgAttk(format!("Attacker>> Injecting a fake status word followed by fake data ...").to_string()),
+            WRD_EMPTY,
+            ErrMsg::MsgAttk(format!("Attacker>> Desynchronizing RT{} ...", self.target).to_string()),
         );
+        let tr = 0;
+        let word_count = 17;
         self.attack_times.push(d.clock.elapsed().as_nanos());
-        let w = Word::new_status(self.target);
+        let w = Word::new_cmd(self.target, word_count, tr);
         d.write(w);
-        for _ in 0..self.word_count {
-            let w = Word::new_data(0x7171);
-            d.log(
-                WRD_EMPTY,
-                ErrMsg::MsgAttk(format!("Fake Data {} ", w).to_string()),
-            );
-            d.write(w);
-        }
+        let w = Word::new_data(0x000F);
+        d.write(w);
+        self.target_found = true;
         self.success = true;
     }
 }
 
-impl EventHandler for DataCorruptionAttack {
+impl EventHandler for DesynchronizationAttackOnRT {
     fn on_cmd(&mut self, d: &mut Device, w: &mut Word) {
-        // This function replaces "find_RT_tcmd" from Michael's code
+        // This function replaces "find_RT_tcmd" and "find_RT_rcmd" from Michael's code
         // We cannot use on_cmd_trx here because that only fires after on_cmd verifies that the address is correct.
         let destination = w.address();
         self.word_count = w.dword_count();
-        if destination == self.target && self.target_found==false && w.tr() == 1 { // do we need the sub address?
+        if destination == self.target && self.target_found==false { // do we need the sub address?
+            if self.flag == 0 {
+                let new_flag;
+                if w.tr() == 1 {
+                    new_flag = 2;
+                    self.word_count = w.dword_count();
+                } else {
+                    new_flag = 1;
+                }
+                self.flag = new_flag;
+            }
+            if w.tr() == 0 {
+                self.word_count = w.dword_count();
+            }
+            self.target_found = true;
             d.log(
                 *w, 
                 ErrMsg::MsgAttk(format!("Attacker>> Target detected(RT{})", self.target).to_string()),
             );
-            self.target_found = true;
-            self.inject(d);
         }
         self.default_on_cmd(d, w);
+    }
+
+    #[allow(unused)]
+    fn on_dat(&mut self, d: &mut Device, w: &mut Word) {
+        // This replaces "watch_data" in Michael's code.
+        if self.word_count > 0 {
+            self.word_count -= 1;
+        }
+        if self.flag == 2 && self.word_count == 0 {
+            // sleep(3);
+            self.desynchronize_rt(d);
+        }
+    }
+
+    fn on_sts(&mut self, d: &mut Device, w: &mut Word) {
+        if w.address() == self.target {
+            if self.flag == 1 && self.word_count == 0 {
+                // sleep(3);
+                self.desynchronize_rt(d);
+            } else if self.flag == 2 {
+
+            }
+        }
     }
 }
 
@@ -88,10 +121,11 @@ pub fn test_attack8() {
             proto: 0,
         },
         // control device-level response
-        handler: DataCorruptionAttack {
+        handler: DesynchronizationAttackOnRT {
             attack_times: Vec::new(),
             word_count: 0u8,
             success: false,
+            flag: 0,
             target: 4, // attacking RT address @4
             target_found: false,
         },

--- a/pkg/src/attacks/attack8.rs
+++ b/pkg/src/attacks/attack8.rs
@@ -1,6 +1,6 @@
 use crate::sys::{
     DefaultEventHandler, DefaultScheduler, Device, ErrMsg, EventHandler, Mode, Router, System,
-    Word, WRD_EMPTY,
+    Word, WRD_EMPTY, AttackType
 };
 
 #[derive(Clone, Debug)]
@@ -107,9 +107,9 @@ pub fn test_attack8() {
         };
 
         if m == 0 {
-            sys.run_d(m as u8, Mode::BC, default_router, false, 0);
+            sys.run_d(m as u8, Mode::BC, default_router, AttackType::Benign);
         } else {
-            sys.run_d(m as u8, Mode::RT, default_router, false, 0);
+            sys.run_d(m as u8, Mode::RT, default_router, AttackType::Benign);
         }
     }
     let attacker_router = Router {
@@ -131,7 +131,7 @@ pub fn test_attack8() {
         },
     };
 
-    sys.run_d(n_devices - 1, Mode::RT, attacker_router, false, 1);
+    sys.run_d(n_devices - 1, Mode::RT, attacker_router, AttackType::AtkDesynchronizationAttackOnRT);
     sys.go();
     sys.sleep_ms(10);
     sys.stop();

--- a/pkg/src/attacks/attack9.rs
+++ b/pkg/src/attacks/attack9.rs
@@ -1,6 +1,6 @@
 use crate::sys::{
     DefaultEventHandler, DefaultScheduler, Device, ErrMsg, EventHandler, Mode, Router, System,
-    Word, WRD_EMPTY,
+    Word, WRD_EMPTY, AttackType
 };
 
 #[derive(Clone, Debug)]
@@ -74,9 +74,9 @@ pub fn test_attack9() {
         };
 
         if m == 0 {
-            sys.run_d(m as u8, Mode::BC, default_router, false, 0);
+            sys.run_d(m as u8, Mode::BC, default_router, AttackType::Benign);
         } else {
-            sys.run_d(m as u8, Mode::RT, default_router, false, 0);
+            sys.run_d(m as u8, Mode::RT, default_router, AttackType::Benign);
         }
     }
     let attacker_router = Router {
@@ -97,7 +97,7 @@ pub fn test_attack9() {
         },
     };
 
-    sys.run_d(n_devices - 1, Mode::RT, attacker_router, false, 1);
+    sys.run_d(n_devices - 1, Mode::RT, attacker_router, AttackType::AtkDataCorruptionAttack);
     sys.go();
     sys.sleep_ms(10);
     sys.stop();

--- a/pkg/src/attacks/attack9.rs
+++ b/pkg/src/attacks/attack9.rs
@@ -4,34 +4,42 @@ use crate::sys::{
 };
 
 #[derive(Clone, Debug)]
-pub struct CommandInvalidationAttack {
+pub struct DataCorruptionAttack {
     pub attack_times: Vec<u128>,
     pub success: bool,
+    pub word_count: u8,
     pub target: u8,         // the target RT
     pub target_found: bool, // target found in traffic
 }
 
-impl CommandInvalidationAttack {
+impl DataCorruptionAttack {
     pub fn inject(&mut self, d: &mut Device) {
-        self.attack_times.push(d.clock.elapsed().as_nanos());
-        let dword_count = 31;    // Maximum number of words.  This will mean the receipient ignores the next 31 messages
-        let tr = 0;              // 1: transmit, 0: receive.  We want to receive because it will sit and wait rather than responding to the BC.
-        let w = Word::new_cmd(self.target, dword_count, tr);
         d.log(
-            WRD_EMPTY,
-            ErrMsg::MsgAttk(format!("Attacker>> Injecting fake command on RT{}", w).to_string()),
+            WRD_EMPTY, 
+            ErrMsg::MsgAttk(format!("Attacker>> Injecting a fake status word followed by fake data ...").to_string()),
         );
+        self.attack_times.push(d.clock.elapsed().as_nanos());
+        let w = Word::new_status(self.target);
         d.write(w);
+        for _ in 0..self.word_count {
+            let w = Word::new_data(0x7171);
+            d.log(
+                WRD_EMPTY,
+                ErrMsg::MsgAttk(format!("Fake Data {} ", w).to_string()),
+            );
+            d.write(w);
+        }
         self.success = true;
     }
 }
 
-impl EventHandler for CommandInvalidationAttack {
+impl EventHandler for DataCorruptionAttack {
     fn on_cmd(&mut self, d: &mut Device, w: &mut Word) {
         // This function replaces "find_RT_tcmd" from Michael's code
         // We cannot use on_cmd_trx here because that only fires after on_cmd verifies that the address is correct.
         let destination = w.address();
-        if destination == self.target && self.target_found==false && w.tr() == 1 {
+        self.word_count = w.dword_count();
+        if destination == self.target && self.target_found==false && w.tr() == 1 { // do we need the sub address?
             d.log(
                 *w, 
                 ErrMsg::MsgAttk(format!("Attacker>> Target detected(RT{})", self.target).to_string()),
@@ -80,8 +88,9 @@ pub fn test_attack9() {
             proto: 0,
         },
         // control device-level response
-        handler: CommandInvalidationAttack {
+        handler: DataCorruptionAttack {
             attack_times: Vec::new(),
+            word_count: 0u8,
             success: false,
             target: 4, // attacking RT address @4
             target_found: false,

--- a/pkg/src/attacks/mod.rs
+++ b/pkg/src/attacks/mod.rs
@@ -1,5 +1,5 @@
-pub mod attack0;
 pub mod attack1;
+pub mod attack10;
 pub mod attack2;
 pub mod attack3;
 pub mod attack4;
@@ -9,5 +9,8 @@ pub mod attack7;
 pub mod attack8;
 pub mod attack9;
 
-pub use {attack0::test_attack0, attack1::test_attack1, attack2::test_attack2, attack3::test_attack3, attack4::test_attack4, 
-    attack5::test_attack5, attack6::test_attack6, attack7::test_attack7, attack8::test_attack8, attack9::test_attack9};
+pub use {
+    attack1::test_attack1, attack10::test_attack10, attack2::test_attack2, attack3::test_attack3,
+    attack4::test_attack4, attack5::test_attack5, attack6::test_attack6, attack7::test_attack7,
+    attack8::test_attack8, attack9::test_attack9,
+};

--- a/pkg/src/main.rs
+++ b/pkg/src/main.rs
@@ -1,8 +1,10 @@
 mod attacks;
 mod sys;
 #[allow(unused_imports)]
-use attacks::{test_attack0, test_attack1, test_attack2, test_attack3,
-        test_attack4, test_attack5, test_attack6, test_attack7, test_attack8, test_attack9};
+use attacks::{
+    test_attack1, test_attack10, test_attack2, test_attack3, test_attack4, test_attack5,
+    test_attack6, test_attack7, test_attack8, test_attack9,
+};
 #[allow(unused_imports)]
 use sys::test_default;
 


### PR DESCRIPTION
- re-indexed attacks from 1-10 instead of starting from 0 (keep 0 as benign) (first commit)
- added AttackType Enum (for #6 to avoid magic numbers)