### PR TITLE
attack9 verification

### DIFF
--- a/pkg/src/attacks/attack1.rs
+++ b/pkg/src/attacks/attack1.rs
@@ -2,6 +2,7 @@ use crate::sys::{
     AttackType, DefaultEventHandler, DefaultScheduler, Device, ErrMsg, EventHandler, Mode, Proto,
     Router, System, Word, WRD_EMPTY,
 };
+use std::sync::{Arc, Mutex};
 
 #[derive(Clone, Debug)]
 pub struct CollisionAttackAgainstTheBus {
@@ -78,9 +79,19 @@ pub fn test_attack1() {
         };
 
         if m == 0 {
-            sys.run_d(m as u8, Mode::BC, default_router, AttackType::Benign);
+            sys.run_d(
+                m as u8,
+                Mode::BC,
+                Arc::new(Mutex::new(default_router)),
+                AttackType::Benign,
+            );
         } else {
-            sys.run_d(m as u8, Mode::RT, default_router, AttackType::Benign);
+            sys.run_d(
+                m as u8,
+                Mode::RT,
+                Arc::new(Mutex::new(default_router)),
+                AttackType::Benign,
+            );
         }
     }
     let attacker_router = Router {
@@ -103,7 +114,7 @@ pub fn test_attack1() {
     sys.run_d(
         n_devices - 1,
         Mode::RT,
-        attacker_router,
+        Arc::new(Mutex::new(attacker_router)),
         AttackType::AtkCollisionAttackAgainstTheBus,
     );
     sys.go();

--- a/pkg/src/attacks/attack10.rs
+++ b/pkg/src/attacks/attack10.rs
@@ -2,6 +2,7 @@ use crate::sys::{
     AttackType, DefaultEventHandler, DefaultScheduler, Device, ErrMsg, EventHandler, Mode, Proto,
     Router, System, Word, WRD_EMPTY,
 };
+use std::sync::{Arc, Mutex};
 
 #[derive(Clone, Debug)]
 pub struct CommandInvalidationAttack {
@@ -69,9 +70,19 @@ pub fn test_attack10() {
         };
 
         if m == 0 {
-            sys.run_d(m as u8, Mode::BC, default_router, AttackType::Benign);
+            sys.run_d(
+                m as u8,
+                Mode::BC,
+                Arc::new(Mutex::new(default_router)),
+                AttackType::Benign,
+            );
         } else {
-            sys.run_d(m as u8, Mode::RT, default_router, AttackType::Benign);
+            sys.run_d(
+                m as u8,
+                Mode::RT,
+                Arc::new(Mutex::new(default_router)),
+                AttackType::Benign,
+            );
         }
     }
     let attacker_router = Router {
@@ -95,7 +106,7 @@ pub fn test_attack10() {
     sys.run_d(
         n_devices - 1,
         Mode::RT,
-        attacker_router,
+        Arc::new(Mutex::new(attacker_router)),
         AttackType::AtkCommandInvalidationAttack,
     );
     sys.go();

--- a/pkg/src/attacks/attack2.rs
+++ b/pkg/src/attacks/attack2.rs
@@ -2,6 +2,7 @@ use crate::sys::{
     AttackType, DefaultEventHandler, DefaultScheduler, Device, ErrMsg, EventHandler, Mode, Proto,
     Router, System, Word, WRD_EMPTY,
 };
+use std::sync::{Arc, Mutex};
 
 #[derive(Clone, Debug)]
 pub struct CollisionAttackAgainstAnRT {
@@ -93,9 +94,19 @@ pub fn test_attack2() {
         };
 
         if m == 0 {
-            sys.run_d(m as u8, Mode::BC, default_router, AttackType::Benign);
+            sys.run_d(
+                m as u8,
+                Mode::BC,
+                Arc::new(Mutex::new(default_router)),
+                AttackType::Benign,
+            );
         } else {
-            sys.run_d(m as u8, Mode::RT, default_router, AttackType::Benign);
+            sys.run_d(
+                m as u8,
+                Mode::RT,
+                Arc::new(Mutex::new(default_router)),
+                AttackType::Benign,
+            );
         }
     }
     let attacker_router = Router {
@@ -121,7 +132,7 @@ pub fn test_attack2() {
     sys.run_d(
         n_devices - 1,
         Mode::RT,
-        attacker_router,
+        Arc::new(Mutex::new(attacker_router)),
         AttackType::AtkCollisionAttackAgainstAnRT,
     );
     sys.go();

--- a/pkg/src/attacks/attack3.rs
+++ b/pkg/src/attacks/attack3.rs
@@ -2,6 +2,7 @@ use crate::sys::{
     AttackType, DefaultEventHandler, DefaultScheduler, Device, ErrMsg, EventHandler, Mode, Proto,
     Router, System, Word, WRD_EMPTY,
 };
+use std::sync::{Arc, Mutex};
 
 #[derive(Clone, Debug)]
 pub struct DataThrashingAgainstRT {
@@ -78,9 +79,19 @@ pub fn test_attack3() {
         };
 
         if m == 0 {
-            sys.run_d(m as u8, Mode::BC, default_router, AttackType::Benign);
+            sys.run_d(
+                m as u8,
+                Mode::BC,
+                Arc::new(Mutex::new(default_router)),
+                AttackType::Benign,
+            );
         } else {
-            sys.run_d(m as u8, Mode::RT, default_router, AttackType::Benign);
+            sys.run_d(
+                m as u8,
+                Mode::RT,
+                Arc::new(Mutex::new(default_router)),
+                AttackType::Benign,
+            );
         }
     }
     let attacker_router = Router {
@@ -105,7 +116,7 @@ pub fn test_attack3() {
     sys.run_d(
         n_devices - 1,
         Mode::RT,
-        attacker_router,
+        Arc::new(Mutex::new(attacker_router)),
         AttackType::AtkDataThrashingAgainstRT,
     );
     sys.go();

--- a/pkg/src/attacks/attack4.rs
+++ b/pkg/src/attacks/attack4.rs
@@ -2,6 +2,7 @@ use crate::sys::{
     AttackType, DefaultEventHandler, DefaultScheduler, Device, ErrMsg, EventHandler, Mode, Proto,
     Router, State, System, Word, WRD_EMPTY,
 };
+use std::sync::{Arc, Mutex};
 
 #[derive(Clone, Debug)]
 pub struct MITMAttackOnRTs {
@@ -115,9 +116,19 @@ pub fn test_attack4() {
         };
 
         if m == 0 {
-            sys.run_d(m as u8, Mode::BC, default_router, AttackType::Benign);
+            sys.run_d(
+                m as u8,
+                Mode::BC,
+                Arc::new(Mutex::new(default_router)),
+                AttackType::Benign,
+            );
         } else {
-            sys.run_d(m as u8, Mode::RT, default_router, AttackType::Benign);
+            sys.run_d(
+                m as u8,
+                Mode::RT,
+                Arc::new(Mutex::new(default_router)),
+                AttackType::Benign,
+            );
         }
     }
     let attacker_router = Router {
@@ -146,7 +157,7 @@ pub fn test_attack4() {
     sys.run_d(
         n_devices - 1,
         Mode::RT,
-        attacker_router,
+        Arc::new(Mutex::new(attacker_router)),
         AttackType::AtkMITMAttackOnRTs,
     );
     sys.go();

--- a/pkg/src/attacks/attack5.rs
+++ b/pkg/src/attacks/attack5.rs
@@ -2,6 +2,7 @@ use crate::sys::{
     AttackType, DefaultEventHandler, DefaultScheduler, Device, ErrMsg, EventHandler, Mode, Proto,
     Router, State, System, Word, WRD_EMPTY,
 };
+use std::sync::{Arc, Mutex};
 
 #[derive(Clone, Debug)]
 pub struct ShutdownAttackRT {
@@ -78,9 +79,19 @@ pub fn test_attack5() {
         };
 
         if m == 0 {
-            sys.run_d(m as u8, Mode::BC, default_router, AttackType::Benign);
+            sys.run_d(
+                m as u8,
+                Mode::BC,
+                Arc::new(Mutex::new(default_router)),
+                AttackType::Benign,
+            );
         } else {
-            sys.run_d(m as u8, Mode::RT, default_router, AttackType::Benign);
+            sys.run_d(
+                m as u8,
+                Mode::RT,
+                Arc::new(Mutex::new(default_router)),
+                AttackType::Benign,
+            );
         }
     }
     let attacker_router = Router {
@@ -105,7 +116,7 @@ pub fn test_attack5() {
     sys.run_d(
         n_devices - 1,
         Mode::RT,
-        attacker_router,
+        Arc::new(Mutex::new(attacker_router)),
         AttackType::AtkShutdownAttackRT,
     );
     sys.go();

--- a/pkg/src/attacks/attack6.rs
+++ b/pkg/src/attacks/attack6.rs
@@ -2,6 +2,7 @@ use crate::sys::{
     AttackType, DefaultEventHandler, DefaultScheduler, Device, ErrMsg, EventHandler, Mode, Proto,
     Router, System, Word, WRD_EMPTY,
 };
+use std::sync::{Arc, Mutex};
 
 #[derive(Clone, Debug)]
 pub struct FakeStatusReccmd {
@@ -100,9 +101,19 @@ pub fn test_attack6() {
         };
 
         if m == 0 {
-            sys.run_d(m as u8, Mode::BC, default_router, AttackType::Benign);
+            sys.run_d(
+                m as u8,
+                Mode::BC,
+                Arc::new(Mutex::new(default_router)),
+                AttackType::Benign,
+            );
         } else {
-            sys.run_d(m as u8, Mode::RT, default_router, AttackType::Benign);
+            sys.run_d(
+                m as u8,
+                Mode::RT,
+                Arc::new(Mutex::new(default_router)),
+                AttackType::Benign,
+            );
         }
     }
     let attacker_router = Router {
@@ -128,7 +139,7 @@ pub fn test_attack6() {
     sys.run_d(
         n_devices - 1,
         Mode::RT,
-        attacker_router,
+        Arc::new(Mutex::new(attacker_router)),
         AttackType::AtkFakeStatusReccmd,
     );
     sys.go();

--- a/pkg/src/attacks/attack7.rs
+++ b/pkg/src/attacks/attack7.rs
@@ -2,6 +2,7 @@ use crate::sys::{
     AttackType, DefaultEventHandler, DefaultScheduler, Device, ErrMsg, EventHandler, Mode, Proto,
     Router, System, Word, WRD_EMPTY,
 };
+use std::sync::{Arc, Mutex};
 
 #[derive(Clone, Debug)]
 pub struct FakeStatusTrcmd {
@@ -83,9 +84,19 @@ pub fn test_attack7() {
         };
 
         if m == 0 {
-            sys.run_d(m as u8, Mode::BC, default_router, AttackType::Benign);
+            sys.run_d(
+                m as u8,
+                Mode::BC,
+                Arc::new(Mutex::new(default_router)),
+                AttackType::Benign,
+            );
         } else {
-            sys.run_d(m as u8, Mode::RT, default_router, AttackType::Benign);
+            sys.run_d(
+                m as u8,
+                Mode::RT,
+                Arc::new(Mutex::new(default_router)),
+                AttackType::Benign,
+            );
         }
     }
     let attacker_router = Router {
@@ -109,7 +120,7 @@ pub fn test_attack7() {
     sys.run_d(
         n_devices - 1,
         Mode::RT,
-        attacker_router,
+        Arc::new(Mutex::new(attacker_router)),
         AttackType::AtkFakeStatusTrcmd,
     );
     sys.go();

--- a/pkg/src/attacks/attack8.rs
+++ b/pkg/src/attacks/attack8.rs
@@ -2,6 +2,7 @@ use crate::sys::{
     AttackType, DefaultEventHandler, DefaultScheduler, Device, ErrMsg, EventHandler, Mode, Proto,
     Router, System, Word, WRD_EMPTY,
 };
+use std::sync::{Arc, Mutex};
 
 #[derive(Clone, Debug)]
 pub struct DesynchronizationAttackOnRT {
@@ -112,9 +113,19 @@ pub fn test_attack8() {
         };
 
         if m == 0 {
-            sys.run_d(m as u8, Mode::BC, default_router, AttackType::Benign);
+            sys.run_d(
+                m as u8,
+                Mode::BC,
+                Arc::new(Mutex::new(default_router)),
+                AttackType::Benign,
+            );
         } else {
-            sys.run_d(m as u8, Mode::RT, default_router, AttackType::Benign);
+            sys.run_d(
+                m as u8,
+                Mode::RT,
+                Arc::new(Mutex::new(default_router)),
+                AttackType::Benign,
+            );
         }
     }
     let attacker_router = Router {
@@ -140,7 +151,7 @@ pub fn test_attack8() {
     sys.run_d(
         n_devices - 1,
         Mode::RT,
-        attacker_router,
+        Arc::new(Mutex::new(attacker_router)),
         AttackType::AtkDesynchronizationAttackOnRT,
     );
     sys.go();

--- a/pkg/src/attacks/attack9.rs
+++ b/pkg/src/attacks/attack9.rs
@@ -1,7 +1,8 @@
 use crate::sys::{
-    AttackType, DefaultEventHandler, DefaultScheduler, Device, ErrMsg, EventHandler, Mode, Proto,
-    Router, System, Word, WRD_EMPTY, EmptyScheduler
+    format_log, AttackType, DefaultEventHandler, DefaultScheduler, Device, EmptyScheduler, ErrMsg,
+    EventHandler, Mode, Proto, Router, State, System, Word, WRD_EMPTY,
 };
+use std::sync::{Arc, Mutex};
 
 #[derive(Clone, Debug)]
 pub struct DataCorruptionAttack {
@@ -14,25 +15,53 @@ pub struct DataCorruptionAttack {
 
 impl DataCorruptionAttack {
     pub fn inject(&mut self, d: &mut Device) {
-        d.log(
-            WRD_EMPTY,
-            ErrMsg::MsgAttk(
-                format!("Attacker>> Injecting a fake status word followed by fake data ...")
-                    .to_string(),
-            ),
-        );
         self.attack_times.push(d.clock.elapsed().as_nanos());
         let w = Word::new_status(self.target);
         d.write(w);
         for _ in 0..self.word_count {
             let w = Word::new_data(0x7171);
-            d.log(
-                WRD_EMPTY,
-                ErrMsg::MsgAttk(format!("Fake Data {} ", w).to_string()),
-            );
+            // make it faster
+            // d.log(
+            //     WRD_EMPTY,
+            //     ErrMsg::MsgAttk(format!("Fake Data {} ", w).to_string()),
+            // );
             d.write(w);
         }
         self.success = true;
+        d.log(
+            WRD_EMPTY,
+            ErrMsg::MsgAttk(
+                format!(
+                    "Attacker>> Injected a fake status word followed by {} fake data ...",
+                    self.word_count
+                )
+                .to_string(),
+            ),
+        );
+    }
+
+    pub fn verify(
+        &self,
+        devices: &std::vec::Vec<std::sync::Arc<std::sync::Mutex<Device>>>,
+        logs: &Vec<(u128, Mode, u32, u8, State, Word, ErrMsg, u128)>,
+    ) -> bool {
+        let mut recieved_faked = 0;
+
+        for l in logs {
+            if l.6 == ErrMsg::MsgBCReady {
+                recieved_faked = 0;
+            }
+            if l.6 == ErrMsg::MsgEntDat
+                && l.5.attk() == (AttackType::AtkDataCorruptionAttack as u32)
+            {
+                println!("{} {}/{}", format_log(&l), recieved_faked, self.word_count);
+                recieved_faked += 1;
+                if recieved_faked == self.word_count {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }
 
@@ -41,8 +70,9 @@ impl EventHandler for DataCorruptionAttack {
         // This function replaces "find_RT_tcmd" from Michael's code
         // We cannot use on_cmd_trx here because that only fires after on_cmd verifies that the address is correct.
         let destination = w.address();
-        self.word_count = w.dword_count();
         if destination == self.target && self.target_found == false && w.tr() == 1 {
+            self.word_count = w.dword_count();
+            println!("!!! {}", self.word_count);
             // do we need the sub address?
             d.log(
                 *w,
@@ -57,12 +87,11 @@ impl EventHandler for DataCorruptionAttack {
     }
 }
 
-#[allow(dead_code)]
-pub fn test_attack9() {
+fn eval_attack9(w_delays: u128, proto: Proto) -> bool {
     // let mut delays_single = Vec::new();
-    let n_devices = 8;
+    let n_devices = 4;
     // normal device has 4ns delays (while attacker has zero)
-    let w_delays = 4000;
+    // let w_delays = 40000;
     let mut sys = System::new(n_devices as u32, w_delays);
 
     // the last device is kept for attacker
@@ -73,67 +102,7 @@ pub fn test_attack9() {
                 total_device: n_devices - 1,
                 target: 0,
                 data: vec![1, 2, 3],
-                proto: Proto::BC2RT,
-                proto_rotate: true,
-            },
-            // control device-level response
-            handler: DefaultEventHandler {},
-        };
-
-        if m == 0 {
-            sys.run_d(m as u8, Mode::BC, default_router, AttackType::Benign);
-        } else {
-            sys.run_d(m as u8, Mode::RT, default_router, AttackType::Benign);
-        }
-    }
-    let attacker_router = Router {
-        // control all communications (bc only)
-        scheduler: DefaultScheduler {
-            total_device: n_devices - 1,
-            target: 0,
-            data: vec![1, 2, 3],
-            proto: Proto::BC2RT,
-            proto_rotate: true,
-        },
-        // control device-level response
-        handler: DataCorruptionAttack {
-            attack_times: Vec::new(),
-            word_count: 0u8,
-            success: false,
-            target: 4, // attacking RT address @4
-            target_found: false,
-        },
-    };
-
-    sys.run_d(
-        n_devices - 1,
-        Mode::RT,
-        attacker_router,
-        AttackType::AtkDataCorruptionAttack,
-    );
-    sys.go();
-    sys.sleep_ms(10);
-    sys.stop();
-    sys.join();
-}
-
-#[allow(dead_code)]
-pub fn eval_attack9() {
-    // let mut delays_single = Vec::new();
-    let n_devices = 10;
-    // normal device has 4ns delays (while attacker has zero)
-    let w_delays = 3000;
-    let mut sys = System::new(n_devices as u32, w_delays);
-
-    // the last device is kept for attacker
-    for m in 0..n_devices - 1 {
-        let default_router = Router {
-            // control all communications (bc only)
-            scheduler: DefaultScheduler {
-                total_device: n_devices - 1,
-                target: 0,
-                data: vec![1, 2, 3],
-                proto: Proto::RT2RT,
+                proto: proto,
                 proto_rotate: false,
             },
             // control device-level response
@@ -141,32 +110,74 @@ pub fn eval_attack9() {
         };
 
         if m == 0 {
-            sys.run_d(m as u8, Mode::BC, default_router, AttackType::Benign);
+            sys.run_d(
+                m as u8,
+                Mode::BC,
+                Arc::new(Mutex::new(default_router)),
+                AttackType::Benign,
+            );
         } else {
-            sys.run_d(m as u8, Mode::RT, default_router, AttackType::Benign);
+            sys.run_d(
+                m as u8,
+                Mode::RT,
+                Arc::new(Mutex::new(default_router)),
+                AttackType::Benign,
+            );
         }
     }
-    let attacker_router = Router {
-        // control all communications (bc only)
-        scheduler: EmptyScheduler{},
-        // control device-level response
-        handler: DataCorruptionAttack {
-            attack_times: Vec::new(),
-            word_count: 0u8,
-            success: false,
-            target: 2, // attacking RT address @4
-            target_found: false,
-        },
+    let attk = DataCorruptionAttack {
+        attack_times: Vec::new(),
+        word_count: 0u8,
+        success: false,
+        target: 2, // attacking RT address @4
+        target_found: false,
     };
+    let attacker_router = Arc::new(Mutex::new(Router {
+        // control all communications (bc only)
+        scheduler: EmptyScheduler {},
+        // control device-level response
+        handler: attk,
+    }));
 
     sys.run_d(
         n_devices - 1,
         Mode::RT,
-        attacker_router,
+        Arc::clone(&attacker_router),
         AttackType::AtkDataCorruptionAttack,
     );
     sys.go();
     sys.sleep_ms(10);
     sys.stop();
-    sys.join();
+    let (devices, logs) = sys.join();
+    let l_router = Arc::clone(&attacker_router);
+    return l_router.lock().unwrap().handler.verify(&devices, &logs);
+    // let l_attk = l_router.unwrap().handler;
+    // .lock().unwrap();
+    // return l_router.unwrap().handler.verify(&devices, &logs);
+    // return handler.verify
+}
+
+#[cfg(test)]
+mod tests {
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+
+    #[test]
+    fn test_attk_9_r2r_succeed() {
+        // 12_000 based on the protocol but there is a probability
+        // of success. so here we made it higher
+        assert!(eval_attack9(20_000, Proto::RT2RT) == true);
+    }
+    #[test]
+    fn test_attk_9_r2r_failed() {
+        assert!(eval_attack9(0, Proto::RT2RT) == false);
+    }
+    #[test]
+    fn test_attk_9_r2b_succeed() {
+        assert!(eval_attack9(20_000, Proto::RT2BC) == true);
+    }
+    #[test]
+    fn test_attk_9_r2b_failed() {
+        assert!(eval_attack9(0, Proto::RT2BC) == false);
+    }
 }

--- a/pkg/src/attacks/attack9.rs
+++ b/pkg/src/attacks/attack9.rs
@@ -166,7 +166,7 @@ mod tests {
     fn test_attk_9_r2r_succeed() {
         // 12_000 based on the protocol but there is a probability
         // of success. so here we made it higher
-        assert!(eval_attack9(20_000, Proto::RT2RT) == true);
+        assert!(eval_attack9(40_000, Proto::RT2RT) == true);
     }
     #[test]
     fn test_attk_9_r2r_failed() {
@@ -174,7 +174,7 @@ mod tests {
     }
     #[test]
     fn test_attk_9_r2b_succeed() {
-        assert!(eval_attack9(20_000, Proto::RT2BC) == true);
+        assert!(eval_attack9(40_000, Proto::RT2BC) == true);
     }
     #[test]
     fn test_attk_9_r2b_failed() {

--- a/pkg/src/attacks/attack9.rs
+++ b/pkg/src/attacks/attack9.rs
@@ -146,7 +146,7 @@ fn eval_attack9(w_delays: u128, proto: Proto) -> bool {
         AttackType::AtkDataCorruptionAttack,
     );
     sys.go();
-    sys.sleep_ms(10);
+    sys.sleep_ms(1000);
     sys.stop();
     let (devices, logs) = sys.join();
     let l_router = Arc::clone(&attacker_router);

--- a/pkg/src/attacks/mod.rs
+++ b/pkg/src/attacks/mod.rs
@@ -12,5 +12,5 @@ pub mod attack9;
 pub use {
     attack1::test_attack1, attack10::test_attack10, attack2::test_attack2, attack3::test_attack3,
     attack4::test_attack4, attack5::test_attack5, attack6::test_attack6, attack7::test_attack7,
-    attack8::test_attack8, attack9::test_attack9,
+    attack8::test_attack8
 };

--- a/pkg/src/main.rs
+++ b/pkg/src/main.rs
@@ -1,12 +1,9 @@
 mod attacks;
 mod sys;
 #[allow(unused_imports)]
-use attacks::{
-    test_attack1, test_attack10, test_attack2, test_attack3, test_attack4, test_attack5,
-    test_attack6, test_attack7, test_attack8, test_attack9,
-};
-
+use sys::{eval_sys, Proto};
 fn main() {
+    let devices = eval_sys(0, 3, Proto::RT2RT, true).0;
     // test_attack0();
     // test_attack1();
     // test_attack2();

--- a/pkg/src/sys.rs
+++ b/pkg/src/sys.rs
@@ -15,7 +15,7 @@ pub const WRD_EMPTY: Word = Word { 0: 0 };
 pub const ATK_DEFAULT_DELAYS: u128 = 4000;
 pub const CONFIG_PRINT_LOGS: bool = false;
 pub const CONFIG_SAVE_DEVICE_LOGS: bool = false;
-pub const CONFIG_SAVE_SYS_LOGS: bool = false;
+pub const CONFIG_SAVE_SYS_LOGS: bool = true;
 
 #[allow(unused)]
 #[derive(Clone, Debug, PartialEq)]


### PR DESCRIPTION
some changes for attack verification

- sys.join return the list of device and merged list of logs (I can't figure out how to reuse sys after the join function...)
- sys.run_d now takes the arc<mutex<router>> instead of router, so the router object can be reused. 
- added the verification interface for attacks (see attack 9)